### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,8 @@ on:
 jobs:
 
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/aledrocomic/gocomicwriter/security/code-scanning/1](https://github.com/aledrocomic/gocomicwriter/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow or job definition, limiting access as much as possible. In this workflow, the steps only require reading the repository contents to check out the code; they do not perform any write actions, issue or pull request modifications, etc. The best practice is to set `permissions: contents: read` at the job level, since only the `build` job is present; or at the workflow root to affect all jobs. Either will suffice here, but per CodeQL's recommendation, adding it at the job level right under the `build:` key is preferred for granularity. No additional methods, definitions, or imports are required; this is purely a configuration fix in the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
